### PR TITLE
mark inconsistent nuget package version with a red border

### DIFF
--- a/DgmlPowerTools.2022/DgmlPowerTools.2022/Utilities/ProjectDependencies.cs
+++ b/DgmlPowerTools.2022/DgmlPowerTools.2022/Utilities/ProjectDependencies.cs
@@ -50,7 +50,7 @@ namespace LovettSoftware.DgmlPowerTools
 
                 AddCategoryStyle(graph, CodeNodeCategories.Assembly, "#FF094167", "CodeSchema_Assembly");
 
-                CodeGraphSchema.Schema.Properties.AddNewProperty(PropNameNugetVersion, typeof(string),
+                GraphProperty versionProperty = CodeGraphSchema.Schema.Properties.AddNewProperty(PropNameNugetVersion, typeof(string),
                     () => {
                         var meta = new GraphMetadata("Version", "Nuget package version", null, GraphMetadataOptions.Serializable | GraphMetadataOptions.Browsable | GraphMetadataOptions.Sharable);
                         meta.SetValue(CodeNodeProperties.IsBrowsable, "True");
@@ -84,7 +84,7 @@ namespace LovettSoftware.DgmlPowerTools
                         GraphCategory projectCategory = GetOrCreateProjectCategoryStyle(graph, custom, kind);
                         GraphNode sourceProjectNode = graph.Nodes.GetOrCreate(id, label, projectCategory);
 
-                        CreateNugetReferences(sourceProject.FullName, graph, sourceProjectNode);
+                        CreateNugetReferences(sourceProject.FullName, graph, sourceProjectNode, versionProperty);
 
                         object[] req = sourceItem.RequiredProjects as object[];
                         if (req != null)
@@ -214,7 +214,7 @@ namespace LovettSoftware.DgmlPowerTools
             return style;
         }
 
-        private static void CreateNugetReferences(string sourceProjectFullName, Graph graph, GraphNode sourceProjectNode)
+        private static void CreateNugetReferences(string sourceProjectFullName, Graph graph, GraphNode sourceProjectNode, GraphProperty versionProp)
         {
             try
             {
@@ -240,7 +240,7 @@ namespace LovettSoftware.DgmlPowerTools
 
                         GraphNode nugetNode = graph.Nodes.GetOrCreate(id, label, CodeNodeCategories.Assembly);
                         if (nugetVersion != null) {
-                            nugetNode.SetValue(PropNameNugetVersion, nugetVersion.ToString());
+                            nugetNode.SetValue(versionProp, nugetVersion.ToString());
                         }
                         graph.Links.GetOrCreate(sourceProjectNode, nugetNode);
 
@@ -250,9 +250,7 @@ namespace LovettSoftware.DgmlPowerTools
                             if (nugetNode.Label == existingNugetNode.Label && nugetNode.Id != existingNugetNode.Id)
                             {
                                 nugetNode.SetStroke(Brushes.Red);
-                                nugetNode.Label += $"\n{nugetNode.GetValue(PropNameNugetVersion)}";
                                 existingNugetNode.SetStroke(Brushes.Red);
-                                existingNugetNode.Label += $"\n{existingNugetNode.GetValue(PropNameNugetVersion)}";
                             }
                         }
                     }

--- a/DgmlPowerTools.2022/DgmlPowerTools.2022/Utilities/ProjectDependencies.cs
+++ b/DgmlPowerTools.2022/DgmlPowerTools.2022/Utilities/ProjectDependencies.cs
@@ -225,22 +225,21 @@ namespace LovettSoftware.DgmlPowerTools
                     string name = (string)e.Attribute("Include");
                     if (!string.IsNullOrEmpty(name))
                     {
-                        string nugetVersionAttribute = (string)e.Attribute(ns + "Version");
-                        if (string.IsNullOrEmpty(nugetVersionAttribute))
+                        string nugetVersion = (string)e.Attribute(ns + "Version");
+                        if (string.IsNullOrEmpty(nugetVersion))
                         {
-                            nugetVersionAttribute = (string)e.Element(ns + "Version");
+                            nugetVersion = (string)e.Element(ns + "Version");
                         }
                         string id = name;
                         string label = name;
-                        Version nugetVersion = null;
-                        if (!string.IsNullOrEmpty(nugetVersionAttribute) && Version.TryParse(nugetVersionAttribute, out nugetVersion))
+                        if (!string.IsNullOrEmpty(nugetVersion))
                         {
                             id += "-" + nugetVersion;
                         }
 
                         GraphNode nugetNode = graph.Nodes.GetOrCreate(id, label, CodeNodeCategories.Assembly);
-                        if (nugetVersion != null) {
-                            nugetNode.SetValue(versionProp, nugetVersion.ToString());
+                        if (!string.IsNullOrEmpty(nugetVersion)) {
+                            nugetNode.SetValue(versionProp, nugetVersion);
                         }
                         graph.Links.GetOrCreate(sourceProjectNode, nugetNode);
 


### PR DESCRIPTION
New:
The nuget package versions are compared and nodes with same package but different version are marked with a red border. Also the version is displayed when different versions are detected:

![image](https://user-images.githubusercontent.com/12518090/162374416-97fa7e05-b55c-43fe-930c-5f6416e2ae3d.png)

To make the red border visible I had to remove the existing "Stroke" style.

Fix:
The "Version" property was not working (not visible in the F4 property window). After renaming the property to "Nuget-Version" it works. I guess the "Version" property is an already reserved keyword.

Remark:
I am working almost only with the new project SDK style. Therefore the checks for different GUIDs to set project styles is not working since the project SDK style does not contain such GUIDs anymore.